### PR TITLE
ensured accessibility

### DIFF
--- a/app/components/hamburger.tsx
+++ b/app/components/hamburger.tsx
@@ -21,6 +21,7 @@ export default function Hamburger({
       aria-label={open ? "Close menu" : "Open menu"}
       aria-expanded={open}
       aria-controls={controlsId}
+      aria-haspopup="menu"
       onClick={onToggle}
       className={`group relative inline-flex h-9 w-11 items-center justify-center rounded-xl border px-3 py-2 text-sm transition
                   border-cyan-400/40 bg-black/50 text-cyan-100 hover:bg-white/10 ${className}`}

--- a/app/components/kebab.tsx
+++ b/app/components/kebab.tsx
@@ -21,6 +21,7 @@ export default function Kebab({
       aria-label={open ? "Close quick menu" : "Open quick menu"}
       aria-expanded={open}
       aria-controls={controlsId}
+      aria-haspopup="menu"
       onClick={onToggle}
       className={`group relative inline-flex h-9 w-10 items-center justify-center rounded-xl border px-3 py-2 text-sm transition
                   border-cyan-400/40 bg-black/50 text-cyan-100 hover:bg-white/10 ${className}`}


### PR DESCRIPTION
Summary

Improves screen-reader announcements for the Hamburger (☰) and Kebab (⋮) buttons by explicitly declaring that they open menus. This clarifies role/behavior and aligns with ARIA menu button patterns.

Changes

app/components/hamburger.tsx: add aria-haspopup="menu" on the trigger button.

app/components/kebab.tsx: add aria-haspopup="menu" on the trigger button.

No visual or behavioral changes for sighted/keyboard users. Attributes only.

Why

Conforms to WCAG 2.2 AA – 4.1.2 Name, Role, Value.

Helps AT announce “menu” context and state alongside aria-expanded.